### PR TITLE
feat: add IP registry for cluster-wide IP address tracking

### DIFF
--- a/lib/epoxi/application.ex
+++ b/lib/epoxi/application.ex
@@ -9,6 +9,7 @@ defmodule Epoxi.Application do
       {Epoxi.Telemetry, []},
       {Registry, keys: :unique, name: Epoxi.Queue.Registry},
       {Epoxi.PipelineSupervisor, []},
+      {Epoxi.IpRegistry, []},
       {Task, fn -> start_pipelines() end},
       {Bandit, Application.get_env(:epoxi, :endpoint_options)}
     ]

--- a/lib/epoxi/cluster.ex
+++ b/lib/epoxi/cluster.ex
@@ -7,19 +7,21 @@ defmodule Epoxi.Cluster do
   - Tracking connected nodes within the cluster
   - Retrieving aggregated state information from all nodes
   - Finding specific nodes within the cluster
+  - Aggregating IP addresses into logical pools across the cluster
 
   It serves as a central component for managing distributed node operations in the Epoxi system.
   """
 
   alias Epoxi.Cluster
 
-  defstruct node_count: 0, nodes: [], pools: %{default: MapSet.new()}
+  defstruct node_count: 0, nodes: [], ip_pools: %{default: %{}}
 
+  @type ip_address :: String.t()
   @type pool_name :: atom()
   @type t :: %__MODULE__{
           node_count: non_neg_integer(),
           nodes: [Epoxi.Node.t()],
-          pools: %{pool_name() => MapSet.t(Epoxi.Node.t())}
+          ip_pools: %{pool_name() => %{atom() => [String.t()]}}
         }
 
   def init(opts \\ []) do
@@ -40,20 +42,50 @@ defmodule Epoxi.Cluster do
 
     cluster =
       Enum.reduce(nodes, cluster, fn node, cluster ->
-        add_node_to_pool(cluster, node)
+        add_node_to_ip_pool(cluster, node)
       end)
 
-    %{cluster | node_count: length(nodes)}
+    %{cluster | nodes: nodes, node_count: length(nodes)}
   end
 
-  @spec add_node_to_pool(cluster :: t(), node :: Epoxi.Node.t()) :: t()
-  def add_node_to_pool(%Cluster{pools: pools} = cluster, %Epoxi.Node{ip_pool: ip_pool} = node) do
-    {_old, new_value} =
-      pools
-      |> Map.put_new(ip_pool, MapSet.new())
-      |> Map.get_and_update(ip_pool, fn map_set -> {map_set, MapSet.put(map_set, node)} end)
+  @spec add_node(cluster :: t(), node :: Epoxi.Node.t()) :: t()
+  def add_node(%Cluster{nodes: nodes} = cluster, %Epoxi.Node{} = node) do
+    node_with_pool = ensure_ip_pool(node)
+    updated_nodes = [node_with_pool | nodes]
 
-    %{cluster | pools: new_value}
+    %{cluster | nodes: updated_nodes}
+    |> add_node_to_ip_pool(node_with_pool)
+  end
+
+  @spec remove_node(cluster :: t(), node_to_remove :: Epoxi.Node.t()) :: t()
+  def remove_node(%Cluster{nodes: nodes} = cluster, node_to_remove) do
+    new_nodes = Enum.reject(nodes, fn node -> node.name == node_to_remove.name end)
+
+    %{cluster | nodes: new_nodes, node_count: length(new_nodes)}
+    |> remove_node_from_ip_pool(node_to_remove)
+  end
+
+  @spec add_node_to_ip_pool(cluster :: t(), node :: Epoxi.Node.t()) :: t()
+  def add_node_to_ip_pool(
+        %Cluster{ip_pools: ip_pools} = cluster,
+        %Epoxi.Node{ip_pool: ip_pool, name: node_name, ip_addresses: ips} = _node
+      ) do
+    new_ip_pools =
+      ip_pools
+      |> Map.put_new(ip_pool, %{})
+      |> put_in([ip_pool, node_name], ips || [])
+
+    %{cluster | ip_pools: new_ip_pools}
+  end
+
+  @spec remove_node_from_ip_pool(cluster :: t(), node_to_remove :: node()) :: t()
+  def remove_node_from_ip_pool(%Cluster{ip_pools: ip_pools} = cluster, node_to_remove) do
+    new_ip_pools =
+      Map.new(ip_pools, fn {pool_name, pool_nodes} ->
+        {pool_name, Map.delete(pool_nodes, node_to_remove.name)}
+      end)
+
+    %{cluster | ip_pools: new_ip_pools}
   end
 
   @spec find_node(node_name :: node()) ::
@@ -66,17 +98,68 @@ defmodule Epoxi.Cluster do
     end)
   end
 
-  @spec find_pool(cluster :: t(), atom()) :: [Epoxi.Node.t()]
-  def find_pool(%Cluster{pools: pools}, pool_name) do
-    pools
-    |> Map.get(pool_name)
-    |> MapSet.to_list()
+  @spec find_node_in_cluster(cluster :: t(), node_name :: node()) ::
+          {:ok, Epoxi.Node.t()} | {:error, :not_found}
+  def find_node_in_cluster(%Cluster{nodes: nodes}, node_name) do
+    case Enum.find(nodes, fn node -> node.name == node_name end) do
+      nil -> {:error, :not_found}
+      node -> {:ok, node}
+    end
+  end
+
+  @spec find_ip_owner(cluster :: t(), ip_address :: String.t()) ::
+          {:ok, Epoxi.Node.t()} | {:error, :not_found}
+  def find_ip_owner(%Cluster{nodes: nodes}, ip_address) do
+    case Enum.find(nodes, fn node -> ip_address in node.ip_addresses end) do
+      nil -> {:error, :not_found}
+      node -> {:ok, node}
+    end
+  end
+
+  @spec find_ip_pool(cluster :: t(), atom()) :: %{atom() => [String.t()]}
+  def find_ip_pool(%Cluster{ip_pools: ip_pools}, pool_name) do
+    Map.get(ip_pools, pool_name, %{})
+  end
+
+  @spec get_all_ips(cluster :: t()) :: [ip_address()]
+  def get_all_ips(%Cluster{nodes: nodes}) do
+    nodes
+    |> Enum.flat_map(& &1.ip_addresses)
+    |> Enum.uniq()
+  end
+
+  @spec get_pool_ips(cluster :: t(), atom()) :: [String.t()]
+  def get_pool_ips(%Cluster{} = cluster, pool_name) do
+    cluster
+    |> find_ip_pool(pool_name)
+    |> Map.values()
+    |> List.flatten()
+  end
+
+  @spec find_nodes_in_pool(cluster :: t(), atom()) :: [Epoxi.Node.t()]
+  def find_nodes_in_pool(%Cluster{nodes: nodes} = cluster, pool_name) do
+    pool_node_names =
+      cluster
+      |> find_ip_pool(pool_name)
+      |> Map.keys()
+      |> MapSet.new()
+
+    Enum.filter(nodes, fn node -> node.name in pool_node_names end)
   end
 
   @spec select_node(cluster :: t(), strategy_fn :: fun()) :: [Epoxi.Node.t()]
   def select_node(%Cluster{nodes: nodes}, strategy_fn \\ fn nodes -> nodes end) do
     strategy_fn.(nodes)
   end
+
+  @spec node_count(cluster :: t()) :: non_neg_integer()
+  def node_count(%Cluster{nodes: nodes}), do: length(nodes)
+
+  defp ensure_ip_pool(%Epoxi.Node{ip_pool: nil} = node) do
+    %{node | ip_pool: :default}
+  end
+
+  defp ensure_ip_pool(%Epoxi.Node{} = node), do: node
 
   defp connected_nodes() do
     [Node.self() | Node.list()]

--- a/lib/epoxi/endpoint.ex
+++ b/lib/epoxi/endpoint.ex
@@ -44,7 +44,7 @@ defmodule Epoxi.Endpoint do
   defp route_to_node(emails, pool) do
     node =
       Epoxi.Cluster.init()
-      |> Epoxi.Cluster.find_pool(pool)
+      |> Epoxi.Cluster.find_nodes_in_pool(pool)
       # TODO: Use algos (round robbin, etc) to select node in pool.
       |> hd()
 

--- a/lib/epoxi/ip_registry.ex
+++ b/lib/epoxi/ip_registry.ex
@@ -1,0 +1,156 @@
+defmodule Epoxi.IpRegistry do
+  @moduledoc """
+  Cluster-wide registry for tracking IP address ownership across nodes.
+
+  This GenServer maintains a distributed view of which IPs are available
+  on which nodes, automatically updating when nodes join or leave the cluster.
+
+  It delegates to {Epoxi.Cluster} for function calling.
+
+  Key responsibilities:
+  - Track IP ownership per node
+  - Monitor node up/down events
+  - Provide cluster-wide IP discovery
+  - Support IP pool aggregation
+  """
+
+  use GenServer
+  require Logger
+
+  defstruct cluster: %Epoxi.Cluster{}
+
+  @type node_name :: atom()
+  @type ip_address :: String.t()
+  @type pool_name :: atom()
+
+  @type t :: %__MODULE__{
+          cluster: Epoxi.Cluster.t()
+        }
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Get all IPs available in a specific pool across the cluster.
+  Returns a map of node_name => [ip_addresses]
+  """
+  @spec get_pool_ips(pool_name()) :: %{node_name() => [ip_address()]}
+  def get_pool_ips(pool_name) do
+    GenServer.call(__MODULE__, {:get_pool_ips, pool_name})
+  end
+
+  @doc """
+  Get all available IPs for a specific node.
+  """
+  @spec get_node_ips(node_name()) :: [ip_address()]
+  def get_node_ips(node_name) do
+    GenServer.call(__MODULE__, {:get_node_ips, node_name})
+  end
+
+  @doc """
+  Find which node owns a specific IP address.
+  """
+  @spec find_ip_owner(ip_address()) :: {:ok, node_name()} | {:error, :not_found}
+  def find_ip_owner(ip_address) do
+    GenServer.call(__MODULE__, {:find_ip_owner, ip_address})
+  end
+
+  @doc """
+  Get all available IPs across the entire cluster.
+  Returns a flat list of all IPs with their owning nodes.
+  """
+  @spec get_all_cluster_ips() :: [{ip_address(), node_name()}]
+  def get_all_cluster_ips() do
+    GenServer.call(__MODULE__, :get_all_cluster_ips)
+  end
+
+  @doc """
+  Force refresh of IP information for all connected nodes.
+  """
+  @spec refresh() :: :ok
+  def refresh() do
+    GenServer.cast(__MODULE__, :refresh)
+  end
+
+  @impl true
+  def init(_opts) do
+    :ok = :net_kernel.monitor_nodes(true, [:nodedown_reason])
+
+    state = %__MODULE__{
+      cluster: Epoxi.Cluster.init()
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call({:get_pool_ips, pool_name}, _from, %{cluster: cluster} = state) do
+    pool_ips = Epoxi.Cluster.get_pool_ips(cluster, pool_name)
+    {:reply, pool_ips, state}
+  end
+
+  @impl true
+  def handle_call({:get_node_ips, node_name}, _from, %{cluster: cluster} = state) do
+    ips =
+      case Epoxi.Cluster.find_node_in_cluster(cluster, node_name) do
+        {:ok, node} -> node.ip_addresses
+        {:error, :not_found} -> []
+      end
+
+    {:reply, ips, state}
+  end
+
+  @impl true
+  def handle_call({:find_ip_owner, ip_address}, _from, %{cluster: cluster} = state) do
+    result = Epoxi.Cluster.find_ip_owner(cluster, ip_address)
+    {:reply, result, state}
+  end
+
+  @impl true
+  def handle_call(:get_all_cluster_ips, _from, %{cluster: cluster} = state) do
+    all_ips = Epoxi.Cluster.get_all_ips(cluster)
+    {:reply, all_ips, state}
+  end
+
+  @impl true
+  def handle_cast(:refresh, %{cluster: cluster} = state) do
+    cur_cluster = Epoxi.Cluster.get_current_state(cluster)
+    new_state = %{state | cluster: cur_cluster}
+    {:noreply, new_state}
+  end
+
+  @impl true
+  def handle_info({:nodeup, node_name, _info}, %{cluster: cluster} = state) do
+    Logger.info("Node #{node_name} joined cluster, discovering IPs")
+
+    node = Epoxi.Node.from_node(node_name)
+
+    Logger.info("Discovered IPs: #{node.ip_addresses}")
+
+    new_cluster = Epoxi.Cluster.add_node(cluster, node)
+    {:noreply, %{state | cluster: new_cluster}}
+  end
+
+  @impl true
+  def handle_info({:nodedown, node_name, reason}, %{cluster: cluster} = state) do
+    Logger.info("Node #{node_name} left cluster (reason: #{inspect(reason)}), removing IPs")
+
+    node = Epoxi.Node.from_node(node_name)
+    new_cluster = Epoxi.Cluster.remove_node(cluster, node)
+
+    {:noreply, %{state | cluster: new_cluster}}
+  end
+
+  @impl true
+  def handle_info(msg, state) do
+    Logger.debug("IpRegistry received unexpected message: #{inspect(msg)}")
+    {:noreply, state}
+  end
+
+  @impl true
+  def terminate(_reason, _state) do
+    :net_kernel.monitor_nodes(false)
+    :ok
+  end
+end

--- a/test/epoxi/ip_registry_test.exs
+++ b/test/epoxi/ip_registry_test.exs
@@ -1,0 +1,42 @@
+defmodule Epoxi.IpRegistryTest do
+  use ExUnit.Case, async: true
+
+  alias Epoxi.IpRegistry
+
+  setup do
+    pid =
+      case start_supervised(IpRegistry) do
+        {:error, {:already_started, pid}} ->
+          pid
+
+        {:ok, pid} ->
+          pid
+      end
+
+    {:ok, %{ip_registry: pid}}
+  end
+
+  test "starts and responds to basic calls", %{ip_registry: ip_registry} do
+    assert Process.alive?(ip_registry)
+
+    ips = IpRegistry.get_all_cluster_ips()
+
+    assert length(ips) > 0
+  end
+
+  test "get_pool_ips/1 returns empty map for non-existent pool" do
+    assert IpRegistry.get_pool_ips(:non_existent_pool) == []
+  end
+
+  test "get_node_ips/1 returns empty list for non-existent node" do
+    assert IpRegistry.get_node_ips(:non_existent_node) == []
+  end
+
+  test "find_ip_owner/1 returns not_found for non-existent IP" do
+    assert IpRegistry.find_ip_owner("192.168.1.1") == {:error, :not_found}
+  end
+
+  test "refresh/0 succeeds" do
+    assert IpRegistry.refresh() == :ok
+  end
+end


### PR DESCRIPTION
- Add Epoxi.IpRegistry GenServer to track IP ownership across nodes
- Refactor Cluster module to use ip_pools instead of node pools
- Add IP discovery, ownership tracking, and pool aggregation functions
- Monitor node join/leave events to automatically update IP registry
- Update function signatures and improve type specifications
- Add comprehensive test coverage for new IP registry functionality

BREAKING CHANGE: Cluster.find_pool/2 renamed to find_nodes_in_pool/2